### PR TITLE
Added support for stdin observable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ Alternatively if you call it with `{ split: true }` option, the observable outpu
  will be an object `{ source: 'stdout', text: '...' }` so you can distinguish
  the outputs.
 
+## Stdin support
+
+If you provide an `observable<string>` in `opts.stdin`, it'll be subscribed upon
+ and fed into the child process stdin. Its completion will terminate stdin stream.
+
 ## Methods
 
 ```js


### PR DESCRIPTION
- as briefly mentionned in #1
- providing an observable<string> as opts.stdin
 will be subscribed to and fed to the proc stdin.
- most child processes will expect wait for
 stdin termination, which will be notified when
 the provided observable completes.
- I don't really need it now, was mostly an excuse to play with the project :smile_cat: