### PR TITLE
Bump up dependences to RxJS 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/paulcbetts/spawn-rx",
   "dependencies": {
     "debug-electron": "^0.0.1",
-    "rxjs": "^5.0.0-beta.11"
+    "rxjs": "^5.0.0-beta.12"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,14 @@
 import path from 'path';
 import net from 'net';
-import { Observable, Subscription, AsyncSubject } from 'rxjs';
 import sfs from 'fs';
+
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/merge';
+import 'rxjs/add/operator/pluck';
+import 'rxjs/add/operator/reduce';
+import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
+import { AsyncSubject } from 'rxjs/AsyncSubject';
 
 const spawnOg = require('child_process').spawn;
 const isWindows = process.platform === 'win32';


### PR DESCRIPTION
This PR includes two changes regarding RxJS v5,

- bump up package version to latest available (beta.12)
- import only necessary operator set, instead of importing whole module which does include all kitchenSink operators.